### PR TITLE
Bugfix/session persistence

### DIFF
--- a/Sources/AdminPanelProvider/Controllers/LoginController.swift
+++ b/Sources/AdminPanelProvider/Controllers/LoginController.swift
@@ -28,18 +28,7 @@ public final class LoginController {
 
             let credentials = Password(username: username, password: password)
             let user = try AdminPanelUser.authenticate(credentials)
-
-            let shouldPersist = req.data["rememberMe"] != nil
-            try req.auth.authenticate(user, persist: shouldPersist)
-            if shouldPersist {
-//                req.cookies.insert(
-//                    Cookie.init(
-//                        name: "rememberMe",
-//                        value: String,
-//                        expires: Date().addingTimeInterval(5_184_000)
-//                    )
-//                )
-            }
+            try req.auth.authenticate(user, persist: true)
 
             var redir = "/admin/dashboard"
             if let next = req.query?["next"]?.string, !next.isEmpty {

--- a/Sources/AdminPanelProvider/Controllers/LoginController.swift
+++ b/Sources/AdminPanelProvider/Controllers/LoginController.swift
@@ -42,6 +42,10 @@ public final class LoginController {
     }
 
     public func landing(req: Request) throws -> ResponseRepresentable {
+        guard !req.auth.isAuthenticated(AdminPanelUser.self) else {
+            return redirect("/admin/dashboard")
+        }
+
         let next = req.query?["next"]
 
         return try renderer.make(

--- a/Sources/AdminPanelProvider/Provider.swift
+++ b/Sources/AdminPanelProvider/Provider.swift
@@ -85,7 +85,7 @@ public final class Provider: Vapor.Provider {
 
     public func boot(_ config: Config) throws {
         try Middlewares.unsecured.append(PanelConfigMiddleware(panelConfig))
-        Middlewares.unsecured.append(SessionsMiddleware(MemorySessions()))
+        //Middlewares.unsecured.append(SessionsMiddleware(MemorySessions()))
         Middlewares.unsecured.append(PersistMiddleware(AdminPanelUser.self))
         Middlewares.unsecured.append(FlashMiddleware())
         Middlewares.unsecured.append(FieldsetMiddleware())

--- a/Sources/AdminPanelProvider/Provider.swift
+++ b/Sources/AdminPanelProvider/Provider.swift
@@ -85,7 +85,6 @@ public final class Provider: Vapor.Provider {
 
     public func boot(_ config: Config) throws {
         try Middlewares.unsecured.append(PanelConfigMiddleware(panelConfig))
-        //Middlewares.unsecured.append(SessionsMiddleware(MemorySessions()))
         Middlewares.unsecured.append(PersistMiddleware(AdminPanelUser.self))
         Middlewares.unsecured.append(FlashMiddleware())
         Middlewares.unsecured.append(FieldsetMiddleware())


### PR DESCRIPTION
- Removes "remember me" leftovers
- Removes session config from this provider, which means the consumer would need to set this up in their project (is setup per default)
- Sneaks in a convenient feature where you're now automatically redirected to the dashboard (from login) if you're already logged in