### PR TITLE
Feature/customizable user

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   MacOS:
     macos:
-      xcode: "9.0"
+      xcode: "9.3.0"
     steps:
       - checkout
       - restore_cache:
@@ -30,7 +30,7 @@ jobs:
             - .build
   Linux:
     docker:
-      - image: brettrtoomey/vapor-ci:0.0.1
+      - image: nodesvapor/vapor-ci:swift-4.1
     steps:
       - checkout
       - restore_cache:

--- a/Package.swift
+++ b/Package.swift
@@ -4,15 +4,16 @@ let package = Package(
     name: "AdminPanelProvider",
     dependencies: [
         // Vapor
-        .Package(url: "https://github.com/vapor/vapor.git", majorVersion: 2),
-        .Package(url: "https://github.com/vapor/leaf-provider.git", majorVersion: 1),
         .Package(url: "https://github.com/vapor/auth-provider.git", majorVersion: 1),
+        .Package(url: "https://github.com/vapor/leaf-provider.git", majorVersion: 1),
+        .Package(url: "https://github.com/vapor/vapor.git", majorVersion: 2),
 
         // Nodes
         .Package(url: "https://github.com/nodes-vapor/flash.git", majorVersion: 1),
-        .Package(url: "https://github.com/nodes-vapor/slugify.git", majorVersion: 1),
-        .Package(url: "https://github.com/nodes-vapor/storage.git", majorVersion: 0, minor: 4),
-        .Package(url: "https://github.com/nodes-vapor/paginator.git", majorVersion: 2, minor: 0),
         .Package(url: "https://github.com/nodes-vapor/audit-provider.git", majorVersion: 0, minor: 1),
+        .Package(url: "https://github.com/nodes-vapor/forms.git", majorVersion: 0, minor: 7),
+        .Package(url: "https://github.com/nodes-vapor/paginator.git", majorVersion: 2, minor: 0),
+        .Package(url: "https://github.com/nodes-vapor/slugify.git", majorVersion: 1),
+        .Package(url: "https://github.com/nodes-vapor/storage.git", majorVersion: 0, minor: 4)
     ]
 )

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Admin Panel ✍️
-[![Swift Version](https://img.shields.io/badge/Swift-3-brightgreen.svg)](http://swift.org)
+[![Swift Version](https://img.shields.io/badge/Swift-4.1-brightgreen.svg)](http://swift.org)
 [![Vapor Version](https://img.shields.io/badge/Vapor-2-F6CBCA.svg)](http://vapor.codes)
 [![Circle CI](https://circleci.com/gh/nodes-vapor/admin-panel-provider/tree/master.svg?style=shield)](https://circleci.com/gh/nodes-vapor/admin-panel-provider)
 [![codebeat badge](https://codebeat.co/badges/2aa06de9-5bb5-4c2e-ad1a-ef6e08273184)](https://codebeat.co/projects/github-com-nodes-vapor-admin-panel-provider-master)
@@ -19,13 +19,6 @@ Admin Panel makes it easy to setup and maintain admin features for your Vapor pr
 ### Install package using SPM
 
 Update your `Package.swift` file:
-
-#### Swift 3
-
-```swift
-.Package(url: "https://github.com/nodes-vapor/admin-panel-provider.git", majorVersion: 0, minor: 6)
-```
-#### Swift 4
 
 ```swift
 .package(url: "https://github.com/nodes-vapor/admin-panel-provider.git", .upToNextMinor(from: "0.6.0")),

--- a/Sources/AdminPanelProvider/Commands/Seeder.swift
+++ b/Sources/AdminPanelProvider/Commands/Seeder.swift
@@ -20,15 +20,7 @@ public final class CustomUserSeeder<U: AdminPanelUserType>: Command, ConfigIniti
     public func run(arguments: [String]) throws {
         console.info("Started the seeder")
 
-        let user = try U(
-            name: "Admin",
-            title: "Default admin account",
-            email: "admin@admin.com",
-            password: "admin",
-            role: "Super Admin",
-            shouldResetPassword: false,
-            avatar: nil
-        )
+        let user = try U.makeSeededUser()
 
         try user.save()
 

--- a/Sources/AdminPanelProvider/Commands/Seeder.swift
+++ b/Sources/AdminPanelProvider/Commands/Seeder.swift
@@ -1,8 +1,10 @@
 import Vapor
 import Console
 
+typealias Seeder = CustomUserSeeder<AdminPanelUser>
+
 /// Seeds the admin panel with a default user
-public final class Seeder: Command, ConfigInitializable {
+public final class CustomUserSeeder<U: AdminPanelUserType>: Command, ConfigInitializable {
     public let id = "admin-panel:seeder"
 
     public let help: [String] = [
@@ -18,7 +20,7 @@ public final class Seeder: Command, ConfigInitializable {
     public func run(arguments: [String]) throws {
         console.info("Started the seeder")
 
-        let user = try AdminPanelUser(
+        let user = try U(
             name: "Admin",
             title: "Default admin account",
             email: "admin@admin.com",

--- a/Sources/AdminPanelProvider/Controllers/AdminPanelUserController.swift
+++ b/Sources/AdminPanelProvider/Controllers/AdminPanelUserController.swift
@@ -82,7 +82,7 @@ public final class CustomAdminPanelUserController<U: AdminPanelUserType> {
             try user.save()
 
             if
-                try req.data.get("shouldSendEmail") ?? false,
+                form.shouldSendEmail,
                 panelConfig.isEmailEnabled,
                 let name = panelConfig.fromName,
                 let email = panelConfig.fromEmail

--- a/Sources/AdminPanelProvider/Controllers/AdminPanelUserController.swift
+++ b/Sources/AdminPanelProvider/Controllers/AdminPanelUserController.swift
@@ -26,7 +26,7 @@ public final class CustomAdminPanelUserController<U: AdminPanelUserType> {
     }
 
     public func index(req: Request) throws -> ResponseRepresentable {
-        let requestingUser = try req.auth.assertAuthenticated(U.self)
+        let requestingUser: U = try req.auth.assertAuthenticated()
         try Gate.assertAllowed(requestingUser, requiredRole: .admin)
         let superAdmins = try U.makeQuery().filter(U.roleKey, "Super Admin").all()
         let admins = try U.makeQuery().filter(U.roleKey, "Admin").all()
@@ -44,14 +44,14 @@ public final class CustomAdminPanelUserController<U: AdminPanelUserType> {
     }
 
     public func create(req: Request) throws -> ResponseRepresentable {
-        let requestingUser = try req.auth.assertAuthenticated(U.self)
+        let requestingUser: U = try req.auth.assertAuthenticated()
         try Gate.assertAllowed(requestingUser, requiredRole: .admin)
         let fieldset = try req.fieldset ?? AdminPanelUserForm().makeNode(in: nil)
         return try renderer.make("AdminPanel/BackendUser/edit", ["fieldset": fieldset], for: req)
     }
 
     public func store(req: Request) throws -> ResponseRepresentable {
-        let requestingUser = try req.auth.assertAuthenticated(U.self)
+        let requestingUser: U = try req.auth.assertAuthenticated()
         try Gate.assertAllowed(requestingUser, requiredRole: .admin)
 
         do {
@@ -149,7 +149,7 @@ public final class CustomAdminPanelUserController<U: AdminPanelUserType> {
             return redirect("/admin/backend/users").flash(.error, "User not found")
         }
 
-        let requestingUser = try req.auth.assertAuthenticated(U.self)
+        let requestingUser: U = try req.auth.assertAuthenticated()
         let allowed = Gate.allow(requestingUser, requiredRole: .admin) || requestingUser.id == user.id
 
         guard allowed else {
@@ -170,7 +170,7 @@ public final class CustomAdminPanelUserController<U: AdminPanelUserType> {
                 return redirect("/admin/backend/users").flash(.error, "User not found")
             }
 
-            let requestingUser = try req.auth.assertAuthenticated(U.self)
+            let requestingUser: U = try req.auth.assertAuthenticated()
             let allowed = Gate.allow(requestingUser, requiredRole: .admin) || requestingUser.id == user.id
 
             guard allowed else {
@@ -262,7 +262,7 @@ public final class CustomAdminPanelUserController<U: AdminPanelUserType> {
     }
 
     public func delete(req: Request) throws -> ResponseRepresentable {
-        let requestingUser = try req.auth.assertAuthenticated(U.self)
+        let requestingUser: U = try req.auth.assertAuthenticated()
         try Gate.assertAllowed(requestingUser, requiredRole: .admin)
 
         let user: U
@@ -282,7 +282,7 @@ public final class CustomAdminPanelUserController<U: AdminPanelUserType> {
     }
 
     public func restore(req: Request) throws -> ResponseRepresentable {
-        let requestingUser = try req.auth.assertAuthenticated(U.self)
+        let requestingUser: U = try req.auth.assertAuthenticated()
         try Gate.assertAllowed(requestingUser, requiredRole: .admin)
 
         let user: U

--- a/Sources/AdminPanelProvider/Controllers/AdminPanelUserController.swift
+++ b/Sources/AdminPanelProvider/Controllers/AdminPanelUserController.swift
@@ -88,13 +88,13 @@ public final class CustomAdminPanelUserController<U: AdminPanelUserType> {
                 avatar = path
             }
 
-            let randomPassword = form.password.isEmpty ? String.random(12) : form.password
+            let password = form.password.isEmpty ? String.random(12) : form.password
 
             let user = try U(
                 name: form.name,
                 title: form.title,
                 email: form.email,
-                password: randomPassword,
+                password: password,
                 role: form.role,
                 shouldResetPassword: form.shouldResetPassword,
                 avatar: avatar
@@ -114,8 +114,8 @@ public final class CustomAdminPanelUserController<U: AdminPanelUserType> {
                     "url": .string(panelConfig.baseUrl)
                 ]
 
-                if !randomPassword.isEmpty {
-                    context["password"] = .string(randomPassword)
+                if !password.isEmpty {
+                    context["password"] = .string(password)
                 }
 
                 mailer?.sendEmail(
@@ -144,7 +144,7 @@ public final class CustomAdminPanelUserController<U: AdminPanelUserType> {
     public func edit(req: Request) throws -> ResponseRepresentable {
         let user: U
         do {
-            user = try req.parameters.next(U.self)
+            user = try req.parameters.next()
         } catch {
             return redirect("/admin/backend/users").flash(.error, "User not found")
         }
@@ -165,7 +165,7 @@ public final class CustomAdminPanelUserController<U: AdminPanelUserType> {
         do {
             var user: U
             do {
-                user = try req.parameters.next(U.self)
+                user = try req.parameters.next()
             } catch {
                 return redirect("/admin/backend/users").flash(.error, "User not found")
             }
@@ -267,7 +267,7 @@ public final class CustomAdminPanelUserController<U: AdminPanelUserType> {
 
         let user: U
         do {
-            user = try req.parameters.next(U.self)
+            user = try req.parameters.next()
         } catch {
             return redirect("/admin/backend/users").flash(.error, "User not found")
         }

--- a/Sources/AdminPanelProvider/Controllers/AdminPanelUserController.swift
+++ b/Sources/AdminPanelProvider/Controllers/AdminPanelUserController.swift
@@ -88,7 +88,7 @@ public final class CustomAdminPanelUserController<U: AdminPanelUserType> {
             try user.save()
 
             if
-                form.shouldSendEmail,
+                form.shouldSendEmail ?? false,
                 panelConfig.isEmailEnabled,
                 let name = panelConfig.fromName,
                 let email = panelConfig.fromEmail

--- a/Sources/AdminPanelProvider/Controllers/LoginController.swift
+++ b/Sources/AdminPanelProvider/Controllers/LoginController.swift
@@ -157,7 +157,9 @@ public final class CustomUserLoginController<U: AdminPanelUserType> {
             return redirect("/admin/login").flash(.error, "User not found")
         }
 
-        try user.updatePassword(password)
+        let hashedPassword = try U.hashPassword(password)
+        user.password = hashedPassword
+        try user.save()
         try token.use()
         return redirect("/admin/login").flash(.success, "Password reset")
     }

--- a/Sources/AdminPanelProvider/Helpers/Gate.swift
+++ b/Sources/AdminPanelProvider/Helpers/Gate.swift
@@ -34,13 +34,13 @@ public class Gate {
     }
 
     /// Returns whether or not a given user has more than or equal permissions than required
-    public static func allow(_ user: AdminPanelUser, requiredRole: Role) -> Bool {
+    public static func allow<U: AdminPanelUserType>(_ user: U, requiredRole: Role) -> Bool {
         guard let role = Role.init(from: user.role) else { return false }
         return allow(role, requiredRole: requiredRole)
     }
 
     /// Throws if a user doesn't have equal or more permissions than required
-    public static func assertAllowed(_ user: AdminPanelUser, requiredRole: Role) throws {
+    public static func assertAllowed<U: AdminPanelUserType>(_ user: U, requiredRole: Role) throws {
         guard allow(user, requiredRole: requiredRole) else {
             // Don't show them this endpoint exists
             throw Abort.notFound

--- a/Sources/AdminPanelProvider/Helpers/UniqueEntityValidator.swift
+++ b/Sources/AdminPanelProvider/Helpers/UniqueEntityValidator.swift
@@ -1,0 +1,47 @@
+import Fluent
+import Forms
+import Validation
+
+internal final class UniqueEntityValidator: Validator {
+    typealias CountEntities = (
+        _ fieldName: String,
+        _ value: String,
+        _ exceptId: Identifier?
+        ) throws -> Int
+
+    private let fieldName: String
+    private let exceptId: Identifier?
+    private let countOfEntities: CountEntities
+    private let errorOnExist: FormFieldValidationError
+
+    internal init(
+        fieldName: String,
+        exceptId: Identifier?,
+        countOfEntities: @escaping CountEntities,
+        errorOnExist: FormFieldValidationError
+    ) {
+        self.countOfEntities = countOfEntities
+        self.errorOnExist = errorOnExist
+        self.exceptId = exceptId
+        self.fieldName = fieldName
+    }
+
+    internal func validate(_ input: String) throws {
+        guard try countOfEntities(fieldName, input, exceptId) == 0 else {
+            throw errorOnExist
+        }
+    }
+}
+
+extension Entity {
+    static func countOfEntities(
+        where fieldName: String,
+        equals input: String,
+        exceptId: Identifier?
+    ) throws -> Int {
+        return try makeQuery()
+            .filter(fieldName, input)
+            .filter(idKey, .notEquals, exceptId)
+            .count()
+    }
+}

--- a/Sources/AdminPanelProvider/Middlewares.swift
+++ b/Sources/AdminPanelProvider/Middlewares.swift
@@ -1,22 +1,6 @@
-import HTTP
 import Vapor
 
 public enum Middlewares {
     public static var unsecured: [Middleware] = []
     public static var secured: [Middleware] = []
-}
-
-public class FieldsetMiddleware: Middleware {
-    let key = "_fieldset"
-    public init() {}
-
-    public func respond(to request: Request, chainingTo next: Responder) throws -> Response {
-        // Add fieldset to next request
-        request.storage[key] = request.session?.data[key]
-        request.session?.data[key] = nil
-
-        let respond = try next.respond(to: request)
-        request.session?.data[key] = respond.storage[key] as? Node ?? nil
-        return respond
-    }
 }

--- a/Sources/AdminPanelProvider/Middlewares/ActivityMiddleware.swift
+++ b/Sources/AdminPanelProvider/Middlewares/ActivityMiddleware.swift
@@ -3,9 +3,11 @@ import Storage
 import Paginator
 import AuditProvider
 
-public final class ActivityMiddleware: Middleware {
+public typealias ActivityMiddleware = CustomUserActivityMiddleware<AdminPanelUser>
+
+public final class CustomUserActivityMiddleware<U: AdminPanelUserType>: Middleware {
     public func respond(to request: Request, chainingTo next: Responder) throws -> Response {
-        if request.auth.isAuthenticated(AdminPanelUser.self) {
+        if request.auth.isAuthenticated(U.self) {
             let node = try AuditEvent.makeQuery().limit(10).all().map { raw -> Node in
                 var node = try raw.makeNode(in: nil)
 
@@ -13,7 +15,7 @@ public final class ActivityMiddleware: Middleware {
                     try node.set("createdAt", createdAt)
                 }
 
-                if let author = try AdminPanelUser.find(raw.authorId) {
+                if let author = try U.find(raw.authorId) {
                     try node.set("author", author.makeNode(in: nil))
                 }
 

--- a/Sources/AdminPanelProvider/Middlewares/ProtectMiddleware.swift
+++ b/Sources/AdminPanelProvider/Middlewares/ProtectMiddleware.swift
@@ -2,11 +2,13 @@ import HTTP
 import Flash
 import Authentication
 
+public typealias ProtectMiddleware = CustomUserProtectMiddleware<AdminPanelUser>
+
 /// Redirects unauthenticated requests to a supplied path.
-public final class ProtectMiddleware: Middleware {
+public final class CustomUserProtectMiddleware<U: AdminPanelUserType>: Middleware {
     public func respond(to req: Request, chainingTo next: Responder) throws -> Response {
         do {
-            if let user = req.auth.authenticated(AdminPanelUser.self), user.shouldResetPassword {
+            if let user = req.auth.authenticated(U.self), user.shouldResetPassword {
                 let redirectPath = "/admin/backend/users/\(user.id?.string ?? "0")/edit"
 
                 if req.uri.path != redirectPath && req.uri.path.replacingOccurrences(of: "/", with: "") != redirectPath.replacingOccurrences(of: "/", with: "") {

--- a/Sources/AdminPanelProvider/Middlewares/ProtectMiddleware.swift
+++ b/Sources/AdminPanelProvider/Middlewares/ProtectMiddleware.swift
@@ -8,7 +8,7 @@ public typealias ProtectMiddleware = CustomUserProtectMiddleware<AdminPanelUser>
 public final class CustomUserProtectMiddleware<U: AdminPanelUserType>: Middleware {
     public func respond(to req: Request, chainingTo next: Responder) throws -> Response {
         do {
-            if let user = req.auth.authenticated(U.self), user.shouldResetPassword {
+            if let user: U = req.auth.authenticated(), user.shouldResetPassword {
                 let redirectPath = "/admin/backend/users/\(user.id?.string ?? "0")/edit"
 
                 if req.uri.path != redirectPath && req.uri.path.replacingOccurrences(of: "/", with: "") != redirectPath.replacingOccurrences(of: "/", with: "") {

--- a/Sources/AdminPanelProvider/Models/Action.swift
+++ b/Sources/AdminPanelProvider/Models/Action.swift
@@ -1,7 +1,9 @@
 import FluentProvider
 
+public typealias Action = CustomUserAction<AdminPanelUser>
+
 /// An event that occured in the admin panel
-public final class Action: Model {
+public final class CustomUserAction<U: AdminPanelUserType>: Model {
     public let storage = Storage()
 
     public var name: String
@@ -35,9 +37,9 @@ public final class Action: Model {
     }
 }
 
-extension Action: Timestampable {}
+extension CustomUserAction: Timestampable {}
 
-extension Action: JSONRepresentable {
+extension CustomUserAction: JSONRepresentable {
     public func makeJSON() throws -> JSON {
         var json = JSON()
 
@@ -51,13 +53,13 @@ extension Action: JSONRepresentable {
     }
 }
 
-extension Action: Preparation {
+extension CustomUserAction: Preparation {
     public static func prepare(_ database: Database) throws {
         try database.create(self) {
             $0.id()
             $0.string("name")
             $0.string("message")
-            $0.foreignId(for: AdminPanelUser.self)
+            $0.foreignId(for: U.self)
         }
     }
 
@@ -66,8 +68,8 @@ extension Action: Preparation {
     }
 }
 
-extension Action {
-    public static func report(_ user: AdminPanelUser, _ message: String) {
+extension CustomUserAction {
+    public static func report(_ user: U, _ message: String) {
         do {
             let action = Action(name: user.name, userId: user.id ?? "0", message: message)
             try action.save()

--- a/Sources/AdminPanelProvider/Models/AdminPanelUser.swift
+++ b/Sources/AdminPanelProvider/Models/AdminPanelUser.swift
@@ -7,8 +7,9 @@ import Storage
 import Vapor
 
 public protocol AdminPanelUserFormType: Form {
-    var role: String? { get }
     var password: String? { get }
+    var role: String? { get }
+    var shouldSendEmail: Bool { get }
 }
 
 public protocol AdminPanelUserType:

--- a/Sources/AdminPanelProvider/Models/AdminPanelUser.swift
+++ b/Sources/AdminPanelProvider/Models/AdminPanelUser.swift
@@ -5,16 +5,63 @@ import AuthProvider
 import AuditProvider
 import FluentProvider
 
+public protocol AdminPanelUserType:
+    NodeRepresentable,
+    Parameterizable,
+    PasswordAuthenticatable,
+    Persistable,
+    Preparation,
+    SoftDeletable,
+    ViewDataRepresentable
+{
+    associatedtype A: Preparation
+
+    init(
+        name: String,
+        title: String,
+        email: String,
+        password: String,
+        role: String,
+        shouldResetPassword: Bool,
+        avatar: String?
+    ) throws
+
+    var avatar: String? { get set }
+    var email: String { get set }
+    var name: String { get set }
+    var password: String { get set }
+    var role: String { get set }
+    var shouldResetPassword: Bool { get set }
+    var title: String { get set }
+
+    /// database key name for `role` property
+    static var roleKey: String { get }
+
+    /// database key name for `email` property
+    static var emailKey: String { get }
+
+    func updatePassword(_ newPass: String) throws
+}
+
+extension AdminPanelUserType {
+    public static var roleKey: String { return "role" }
+    public static var emailKey: String { return "email" }
+}
+
+extension AdminPanelUser: AdminPanelUserType {
+    public typealias A = Action
+}
+
 public final class AdminPanelUser: Model {
     public let storage = Storage()
 
-    public var name: String
-    public var title: String
+    public var avatar: String?
     public var email: String
+    public var name: String
     public var password: String
     public var role: String
     public var shouldResetPassword: Bool
-    public var avatar: String?
+    public var title: String
 
     public var avatarUrl: String {
         return avatar ?? "https://api.adorable.io/avatars/150/\(email).png"
@@ -41,9 +88,9 @@ public final class AdminPanelUser: Model {
     public init(row: Row) throws {
         name = try row.get("name")
         title = try row.get("title")
-        email = try row.get("email")
+        email = try row.get(AdminPanelUser.emailKey)
         password = try row.get("password")
-        role = try row.get("role")
+        role = try row.get(AdminPanelUser.roleKey)
         shouldResetPassword = try row.get(AdminPanelUser.shouldResetPasswordKey)
         avatar = row["avatar"]?.string
     }
@@ -53,9 +100,9 @@ public final class AdminPanelUser: Model {
 
         try row.set("name", name)
         try row.set("title", title)
-        try row.set("email", email)
+        try row.set(AdminPanelUser.emailKey, email)
         try row.set("password", password)
-        try row.set("role", role)
+        try row.set(AdminPanelUser.roleKey, role)
         try row.set(AdminPanelUser.shouldResetPasswordKey, shouldResetPassword)
         try row.set("avatar", avatar)
 
@@ -76,8 +123,8 @@ extension AdminPanelUser: ViewDataRepresentable {
             "id": .string(id?.string ?? "0"),
             "name": .string(name),
             "title": .string(title),
-            "email": .string(email),
-            "role": .string(role),
+            AdminPanelUser.emailKey: .string(email),
+            AdminPanelUser.roleKey: .string(role),
             "avatarUrl": .string(Storage.getCDNPath(optional: avatar) ?? avatarUrl)
         ])
     }
@@ -90,7 +137,7 @@ extension AdminPanelUser: NodeRepresentable {
             "name": .string(name),
             "title": .string(title),
             "email": .string(email),
-            "role": .string(role),
+            AdminPanelUser.roleKey: .string(role),
             "avatarUrl": .string(Storage.getCDNPath(optional: avatar) ?? avatarUrl)
         ])
     }
@@ -106,9 +153,9 @@ extension AdminPanelUser: Preparation {
             $0.id()
             $0.string("name")
             $0.string("title")
-            $0.string("email")
+            $0.string(AdminPanelUser.emailKey)
             $0.string("password")
-            $0.string("role")
+            $0.string(AdminPanelUser.roleKey)
             $0.bool(AdminPanelUser.shouldResetPasswordKey)
             $0.string("avatar", optional: true)
         }
@@ -121,7 +168,7 @@ extension AdminPanelUser: Preparation {
 extension AdminPanelUser: PasswordAuthenticatable {
     public static func authenticate(_ credentials: Password) throws -> AdminPanelUser {
         guard
-            let user = try AdminPanelUser.makeQuery().filter("email", credentials.username).first(),
+            let user = try makeQuery().filter(AdminPanelUser.emailKey, credentials.username).first(),
             try BCryptHasher().check(credentials.password, matchesHash: user.password)
         else {
             throw Abort.unauthorized

--- a/Sources/AdminPanelProvider/Models/AdminPanelUser.swift
+++ b/Sources/AdminPanelProvider/Models/AdminPanelUser.swift
@@ -9,7 +9,7 @@ import Vapor
 public protocol AdminPanelUserFormType: Form {
     var password: String? { get }
     var role: String? { get }
-    var shouldSendEmail: Bool { get }
+    var shouldSendEmail: Bool? { get }
 }
 
 public protocol AdminPanelUserType:
@@ -130,7 +130,7 @@ extension AdminPanelUser: AdminPanelUserType {
 
         if let password = form.password, !password.isEmpty {
             newPassword = password
-            shouldResetPassword = form.shouldResetPassword
+            shouldResetPassword = form.shouldResetPassword ?? false
         } else {
             newPassword = "" // this will be overwritten by the controller!
             shouldResetPassword = true

--- a/Sources/AdminPanelProvider/Models/AdminPanelUser.swift
+++ b/Sources/AdminPanelProvider/Models/AdminPanelUser.swift
@@ -23,7 +23,6 @@ public protocol AdminPanelUserType:
     ViewDataRepresentable
 {
     static func makeSeededUser() throws -> Self
-    static func makeSSOUser(withEmail: String) throws -> Self
 
     associatedtype Form: AdminPanelUserFormType, RequestInitializable
 
@@ -87,18 +86,6 @@ extension AdminPanelUser: AdminPanelUserType {
             title: "Default admin account",
             email: "admin@admin.com",
             password: "admin",
-            role: "Super Admin",
-            shouldResetPassword: false,
-            avatar: nil
-        )
-    }
-
-    public static func makeSSOUser(withEmail email: String) throws -> AdminPanelUser {
-        return try .init(
-            name: "Admin",
-            title: "Nodes Admin",
-            email: email,
-            password: String.random(16),
             role: "Super Admin",
             shouldResetPassword: false,
             avatar: nil

--- a/Sources/AdminPanelProvider/Models/AdminPanelUserForm.swift
+++ b/Sources/AdminPanelProvider/Models/AdminPanelUserForm.swift
@@ -53,9 +53,9 @@ public struct AdminPanelUserForm {
 extension AdminPanelUserForm {
     public static func validating(_ data: Content, ignoreRole: Bool = false) -> (AdminPanelUserForm, Bool) {
         let name = data["name"]?.string
-        let email = data["email"]?.string
+        let email = data[AdminPanelUser.emailKey]?.string
         let title = data["title"]?.string
-        let role = data["role"]?.string
+        let role = data[AdminPanelUser.roleKey]?.string
         let shouldResetPassword = data["shouldResetPassword"]?.string != nil
         let sendEmail = data["sendEmail"]?.string != nil
         let password = data["password"]?.string
@@ -220,7 +220,7 @@ extension AdminPanelUserForm: NodeRepresentable {
         try node.set("name", nameObj)
         try node.set("email", emailObj)
         try node.set("title", titleObj)
-        try node.set("role", roleObj)
+        try node.set(AdminPanelUser.roleKey, roleObj)
         try node.set("shouldResetPassword", shouldResetPasswordObj)
         try node.set("sendEmail", sendEmailObj)
         try node.set("password", passwordObj)

--- a/Sources/AdminPanelProvider/Models/AdminPanelUserForm.swift
+++ b/Sources/AdminPanelProvider/Models/AdminPanelUserForm.swift
@@ -10,6 +10,7 @@ public struct AdminPanelUserForm: AdminPanelUserFormType {
     public let titleField: FormField<String>
     public let roleField: FormField<String>
     public let shouldResetPasswordField: FormField<Bool>
+    public let shouldSendEmailField: FormField<Bool>
 
     init(
         userId: Identifier? = nil,
@@ -19,7 +20,8 @@ public struct AdminPanelUserForm: AdminPanelUserFormType {
         title: String? = nil,
         role: String? = nil,
         avatar: String? = nil,
-        shouldResetPassword: Bool = false
+        shouldResetPassword: Bool = false,
+        shouldSendEmail: Bool = false
     ) {
         let stringLengthValidator = Count<String>.containedIn(low: 1, high: 191)
 
@@ -46,7 +48,7 @@ public struct AdminPanelUserForm: AdminPanelUserFormType {
             validator: emailValidator.allowingNil(false)
         )
         // TODO: add more password restrictions
-        let passwordValidator = Count<String>.containedIn(low: 6, high: 191)
+        let passwordValidator = Count<String>.containedIn(low: 8, high: 191)
         passwordField = FormField(
             key: "password",
             label: "Password",
@@ -70,6 +72,11 @@ public struct AdminPanelUserForm: AdminPanelUserFormType {
             label: "Should Reset Password",
             value: shouldResetPassword
         )
+        shouldSendEmailField = FormField(
+            key: "shouldSendEmail",
+            label: "Send Email with Info",
+            value: shouldSendEmail
+        )
     }
 }
 
@@ -81,7 +88,8 @@ extension AdminPanelUserForm {
             passwordField,
             titleField,
             roleField,
-            shouldResetPasswordField
+            shouldResetPasswordField,
+            shouldSendEmailField
         ]
     }
 }
@@ -104,6 +112,9 @@ extension AdminPanelUserForm {
     }
     public var shouldResetPassword: Bool {
         return shouldResetPasswordField.value ?? false
+    }
+    public var shouldSendEmail: Bool {
+        return shouldSendEmailField.value ?? false
     }
 }
 
@@ -141,7 +152,8 @@ extension AdminPanelUserForm: RequestInitializable {
             password: content.get("password"),
             title: content.get("title"),
             role: content.get("role"),
-            shouldResetPassword: content.get("shouldResetPassword")
+            shouldResetPassword: content.get("shouldResetPassword"),
+            shouldSendEmail: content.get("shouldSendEmail")
         )
     }
 }

--- a/Sources/AdminPanelProvider/Models/AdminPanelUserForm.swift
+++ b/Sources/AdminPanelProvider/Models/AdminPanelUserForm.swift
@@ -67,7 +67,7 @@ public struct AdminPanelUserForm: AdminPanelUserFormType {
             key: "passwordRepeat",
             label: "Repeat password",
             value: passwordRepeat,
-            validator: Equals(password ?? "")
+            validator: Equals<String?>(password ?? "")
                 .transformingErrors(
                     to: ValidatorError.failure(type: "Password", reason: "Passwords do not match")
                 )

--- a/Sources/AdminPanelProvider/Models/AdminPanelUserForm.swift
+++ b/Sources/AdminPanelProvider/Models/AdminPanelUserForm.swift
@@ -48,7 +48,7 @@ public struct AdminPanelUserForm: AdminPanelUserFormType {
             validator: emailValidator.allowingNil(false)
         )
         // TODO: add more password restrictions
-        let passwordValidator = Count<String>.containedIn(low: 8, high: 191)
+        let passwordValidator = Count<String>.equals(0) || Count.containedIn(low: 8, high: 191)
         passwordField = FormField(
             key: "password",
             label: "Password",

--- a/Sources/AdminPanelProvider/Models/AdminPanelUserForm.swift
+++ b/Sources/AdminPanelProvider/Models/AdminPanelUserForm.swift
@@ -7,6 +7,7 @@ public struct AdminPanelUserForm: AdminPanelUserFormType {
     public let nameField: FormField<String>
     public let emailField: FormField<String>
     public let passwordField: FormField<String>
+    public let passwordRepeatField: FormField<String>
     public let titleField: FormField<String>
     public let roleField: FormField<String>
     public let shouldResetPasswordField: FormField<Bool>
@@ -17,6 +18,7 @@ public struct AdminPanelUserForm: AdminPanelUserFormType {
         name: String? = nil,
         email: String? = nil,
         password: String? = nil,
+        passwordRepeat: String? = nil,
         title: String? = nil,
         role: String? = nil,
         avatar: String? = nil,
@@ -54,6 +56,21 @@ public struct AdminPanelUserForm: AdminPanelUserFormType {
             label: "Password",
             value: password,
             validator: passwordValidator.allowingNil(true)
+                .transformingErrors(
+                    to: ValidatorError.failure(
+                        type: "Password",
+                        reason: "Password must be at least 8 characters."
+                    )
+            )
+        )
+        passwordRepeatField = FormField(
+            key: "passwordRepeat",
+            label: "Repeat password",
+            value: passwordRepeat,
+            validator: Equals(password ?? "")
+                .transformingErrors(
+                    to: ValidatorError.failure(type: "Password", reason: "Passwords do not match")
+                )
         )
         titleField = FormField(
             key: "title",
@@ -69,12 +86,12 @@ public struct AdminPanelUserForm: AdminPanelUserFormType {
         )
         shouldResetPasswordField = FormField(
             key: "shouldResetPassword",
-            label: "Should Reset Password",
+            label: "Should reset password",
             value: shouldResetPassword
         )
         shouldSendEmailField = FormField(
             key: "shouldSendEmail",
-            label: "Send Email with Info",
+            label: "Send email with info",
             value: shouldSendEmail
         )
     }
@@ -86,6 +103,7 @@ extension AdminPanelUserForm {
             nameField,
             emailField,
             passwordField,
+            passwordRepeatField,
             titleField,
             roleField,
             shouldResetPasswordField,
@@ -104,17 +122,20 @@ extension AdminPanelUserForm {
     public var password: String? {
         return passwordField.value
     }
+    public var passwordRepeat: String? {
+        return passwordRepeatField.value
+    }
     public var title: String? {
         return titleField.value
     }
     public var role: String? {
         return roleField.value
     }
-    public var shouldResetPassword: Bool {
-        return shouldResetPasswordField.value ?? false
+    public var shouldResetPassword: Bool? {
+        return shouldResetPasswordField.value
     }
-    public var shouldSendEmail: Bool {
-        return shouldSendEmailField.value ?? false
+    public var shouldSendEmail: Bool? {
+        return shouldSendEmailField.value
     }
 }
 
@@ -150,6 +171,7 @@ extension AdminPanelUserForm: RequestInitializable {
             name: content.get("name"),
             email: content.get("email"),
             password: content.get("password"),
+            passwordRepeat: content.get("passwordRepeat"),
             title: content.get("title"),
             role: content.get("role"),
             shouldResetPassword: content.get("shouldResetPassword"),

--- a/Sources/AdminPanelProvider/Provider.swift
+++ b/Sources/AdminPanelProvider/Provider.swift
@@ -1,15 +1,20 @@
-import Flash
-import Vapor
-import Storage
-import Sessions
-import AuthProvider
-import LeafProvider
-import Leaf
 import AuditProvider
+import AuthProvider
+import Flash
+import Forms
+import Leaf
+import LeafProvider
 import Paginator
+import Sessions
+import Storage
+import Vapor
 
-public final class Provider: Vapor.Provider {
-    public static let repositoryName = "nodes-vapor/admin-panel-provider"
+public typealias Provider = CustomUserProvider<AdminPanelUser>
+
+public final class CustomUserProvider<U: AdminPanelUserType>: Vapor.Provider {
+    public static var repositoryName: String {
+        return "nodes-vapor/admin-panel-provider"
+    }
     public var panelConfig: PanelConfig
 
     public init(panelConfig: PanelConfig) {
@@ -85,20 +90,20 @@ public final class Provider: Vapor.Provider {
 
     public func boot(_ config: Config) throws {
         try Middlewares.unsecured.append(PanelConfigMiddleware(panelConfig))
-        Middlewares.unsecured.append(PersistMiddleware(AdminPanelUser.self))
+        Middlewares.unsecured.append(PersistMiddleware(U.self))
         Middlewares.unsecured.append(FlashMiddleware())
         Middlewares.unsecured.append(FieldsetMiddleware())
-        Middlewares.unsecured.append(ActivityMiddleware())
+        Middlewares.unsecured.append(CustomUserActivityMiddleware<U>())
 
         Middlewares.secured = Middlewares.unsecured
-        Middlewares.secured.append(ProtectMiddleware())
-        Middlewares.secured.append(PasswordAuthenticationMiddleware(AdminPanelUser.self))
+        Middlewares.secured.append(CustomUserProtectMiddleware<U>())
+        Middlewares.secured.append(PasswordAuthenticationMiddleware(U.self))
 
-        config.preparations.append(AdminPanelUser.self)
+        config.preparations.append(U.self)
         config.preparations.append(AdminPanelUserResetToken.self)
-        config.preparations.append(Action.self)
+        config.preparations.append(U.A.self)
 
-        config.addConfigurable(command: Seeder.init, name: "admin-panel:seeder")
+        config.addConfigurable(command: CustomUserSeeder<U>.init, name: "admin-panel:seeder")
         try config.addProvider(AuditProvider.Provider.self)
         try config.addProvider(PaginatorProvider.self)
     }
@@ -146,7 +151,7 @@ public final class Provider: Vapor.Provider {
     public func beforeRun(_ droplet: Droplet) throws {}
 }
 
-extension Provider {
+extension CustomUserProvider {
     public func registerLeafTags(_ renderer: LeafRenderer) {
         let stem = renderer.stem
         stem.register(Box())

--- a/Sources/AdminPanelProvider/Routes/AdminPanelUserRoutes.swift
+++ b/Sources/AdminPanelProvider/Routes/AdminPanelUserRoutes.swift
@@ -1,8 +1,10 @@
 import HTTP
 import Vapor
 
-public final class AdminPanelUserRoutes: RouteCollection {
-    public let controller: AdminPanelUserController
+public typealias AdminPanelUserRoutes = CustomAdminPanelUserRoutes<AdminPanelUser>
+
+public final class CustomAdminPanelUserRoutes<U: AdminPanelUserType>: RouteCollection {
+    public let controller: CustomAdminPanelUserController<U>
 
     public init(
         renderer: ViewRenderer,
@@ -10,7 +12,7 @@ public final class AdminPanelUserRoutes: RouteCollection {
         mailer: MailProtocol?,
         panelConfig: PanelConfig
     ) {
-        controller = AdminPanelUserController(
+        controller = CustomAdminPanelUserController<U>(
             renderer: renderer,
             env: env,
             mailer: mailer,
@@ -26,10 +28,10 @@ public final class AdminPanelUserRoutes: RouteCollection {
         admin.get("backend/users/create", handler: controller.create)
         admin.post("backend/users/store", handler: controller.store)
 
-        admin.get("backend/users/", AdminPanelUser.parameter, "edit", handler: controller.edit)
-        admin.post("backend/users/", AdminPanelUser.parameter, "edit", handler: controller.update)
+        admin.get("backend/users/", U.parameter, "edit", handler: controller.edit)
+        admin.post("backend/users/", U.parameter, "edit", handler: controller.update)
 
-        admin.post("backend/users/", AdminPanelUser.parameter, "delete", handler: controller.delete)
+        admin.post("backend/users/", U.parameter, "delete", handler: controller.delete)
         admin.get("backend/users/", Int.parameter, "restore", handler: controller.restore)
 
         admin.get("backend/users/logout", handler: controller.logout)

--- a/Sources/AdminPanelProvider/Routes/LoginRoutes.swift
+++ b/Sources/AdminPanelProvider/Routes/LoginRoutes.swift
@@ -2,10 +2,12 @@ import HTTP
 import Vapor
 import AuthProvider
 
-public final class LoginRoutes: RouteCollection {
-    public let controller: LoginController
+public typealias LoginRoutes = CustomUserLoginRoutes<AdminPanelUser>
 
-    public init(controller: LoginController) {
+public final class CustomUserLoginRoutes<U: AdminPanelUserType>: RouteCollection {
+    public let controller: CustomUserLoginController<U>
+
+    public init(controller: CustomUserLoginController<U>) {
         self.controller = controller
     }
 

--- a/Sources/AdminPanelProvider/Tags/Leaf/Request+Active.swift
+++ b/Sources/AdminPanelProvider/Tags/Leaf/Request+Active.swift
@@ -25,7 +25,6 @@ extension Request {
             }
         }
         
-        
         return false
     }
 }


### PR DESCRIPTION
This PR allows using a different user type than the usual `AdminPanelUser` as long as it conforms to `AdminPanelUserType`. I've tried to keep the current API in tact by using type aliases.
This PR also fixes the issue that user selected passwords would be emailed in plain text. Now it only does that when a random password was generated.