### PR TITLE
Check for null before checking for bool value

### DIFF
--- a/Sources/AdminPanelProvider/Tags/Leaf/CheckboxGroup.swift
+++ b/Sources/AdminPanelProvider/Tags/Leaf/CheckboxGroup.swift
@@ -15,7 +15,10 @@ public final class CheckboxGroup: BasicTag {
         }
 
         // Retrieve input value, value from fieldset else passed default value
-        let inputValue = fieldset?["value"]?.bool ?? arguments[1]?.bool ?? false
+        var inputValue = arguments[1]?.bool ?? false
+        if let fieldsetValue = fieldset?["value"], fieldsetValue.isNull == false {
+            inputValue = fieldsetValue.bool ?? false
+        }
 
         let label = fieldset?["label"]?.string ?? fieldsetPath
 


### PR DESCRIPTION
When `CheckboxGroup` checks the bool value of the `fieldset` it's always returning `false` as this expression always returns `false` if a fieldset value (wrapper) is available:

```
let inputValue = fieldset?["value"]?.bool ?? arguments[1]?.bool ?? false
```

This PR adds a check for null before checking the bool value.