### PR TITLE
Addressing issues with admin user creation

### DIFF
--- a/Resources/Views/AdminPanel/BackendUser/edit.leaf
+++ b/Resources/Views/AdminPanel/BackendUser/edit.leaf
@@ -134,7 +134,7 @@ $(function() {
                 #if(request.storage.adminPanel.isEmailEnabled) {
                     #if(user) {
                     } ##else() {
-                        #form:checkboxgroup(fieldset.sendEmail, true)
+                        #form:checkboxgroup(fieldset.shouldSendEmail, true)
                     }
                 }
                 

--- a/Sources/AdminPanelProvider/Helpers/Content+Bool.swift
+++ b/Sources/AdminPanelProvider/Helpers/Content+Bool.swift
@@ -1,0 +1,8 @@
+import Vapor
+
+extension Content {
+    func getBool(_ path: String) throws -> Bool {
+        let string: String? = try get(path)
+        return string == path
+    }
+}

--- a/Sources/AdminPanelProvider/Models/AdminPanelUser.swift
+++ b/Sources/AdminPanelProvider/Models/AdminPanelUser.swift
@@ -135,7 +135,7 @@ extension AdminPanelUser: AdminPanelUserType {
             name: values.name,
             title: values.title,
             email: values.email,
-            password: AdminPanelUser.hashPassword(newPassword),
+            password: newPassword,
             role: values.role,
             shouldResetPassword: shouldResetPassword,
             avatar: avatar

--- a/Sources/AdminPanelProvider/Models/AdminPanelUserForm.swift
+++ b/Sources/AdminPanelProvider/Models/AdminPanelUserForm.swift
@@ -168,6 +168,7 @@ extension AdminPanelUserForm: RequestInitializable {
     public init(request: Request) throws {
         let content = request.data
         try self.init(
+            userId: content.get("id"),
             name: content.get("name"),
             email: content.get("email"),
             password: content.get("password"),
@@ -183,6 +184,7 @@ extension AdminPanelUserForm: RequestInitializable {
 extension AdminPanelUserForm {
     public init(user: AdminPanelUser) {
         self.init(
+            userId: user.id,
             name: user.name,
             email: user.email,
             title: user.title,

--- a/Sources/AdminPanelProvider/Models/AdminPanelUserForm.swift
+++ b/Sources/AdminPanelProvider/Models/AdminPanelUserForm.swift
@@ -174,8 +174,8 @@ extension AdminPanelUserForm: RequestInitializable {
             passwordRepeat: content.get("passwordRepeat"),
             title: content.get("title"),
             role: content.get("role"),
-            shouldResetPassword: content.get("shouldResetPassword"),
-            shouldSendEmail: content.get("shouldSendEmail")
+            shouldResetPassword: try content.getBool("shouldResetPassword"),
+            shouldSendEmail: try content.getBool("shouldSendEmail")
         )
     }
 }

--- a/Sources/AdminPanelProvider/Models/AdminPanelUserForm.swift
+++ b/Sources/AdminPanelProvider/Models/AdminPanelUserForm.swift
@@ -175,8 +175,8 @@ extension AdminPanelUserForm: RequestInitializable {
             passwordRepeat: content.get("passwordRepeat"),
             title: content.get("title"),
             role: content.get("role"),
-            shouldResetPassword: try content.getBool("shouldResetPassword"),
-            shouldSendEmail: try content.getBool("shouldSendEmail")
+            shouldResetPassword: content.getBool("shouldResetPassword"),
+            shouldSendEmail: content.getBool("shouldSendEmail")
         )
     }
 }


### PR DESCRIPTION
## Fixes

- Admin users created via Admin Panel backend can sign in now (removed double-hashing of passwords)
- Checkboxes for sending credentials to the user and forcing a password reset work properly now (fixed typo in `.leaf-file` and added proper `bool-parsing` for leaf checkbox)
- Admin users can be edited without changing their email address (added missing `userId` needed for proper validation)